### PR TITLE
Fix: Correct Hardship UI flow and improve click robustness

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -33,6 +33,10 @@ const notepadMenuButton = document.getElementById('notepad-menu-button');
 
 
 function toggleOption(optionElement) {
+    if (!optionElement || typeof optionElement.textContent === 'undefined') {
+        // console.warn("toggleOption called with invalid element:", optionElement);
+        return;
+    }
     let text = optionElement.textContent;
     if (text.endsWith('*')) {
         optionElement.textContent = text.slice(0, -1);
@@ -214,7 +218,8 @@ hardshipOption.addEventListener('click', function() {
     toggleOption(hardshipOption);
     const isActive = hardshipOption.textContent.endsWith('*');
     hardshipMenuButton.classList.toggle('hidden', !isActive);
-    notepadMenuButton.classList.toggle('hidden', !isActive);
+    // notepadMenuButton should remain visible for panel switching.
+    // Its visibility is managed by default HTML and panel switching logic, not directly by hardshipOption state.
 });
 
 amountInputsContainer.addEventListener('click', function(event) {


### PR DESCRIPTION
Addresses issues with the Hardship feature visibility and panel switching.
- Corrected logic for `hardshipOption` in `actions.js` to ensure the top bar `hardshipMenuButton` appears correctly when "Hardship*" is active, and the `notepadMenuButton` remains visible for panel switching.
- Added a defensive check to the `toggleOption` function in `actions.js` for increased robustness.

Known Issues:
- A ReferenceError for `userInitials` in `shortcuts.js` was identified as a likely cause for widespread clickability problems if Ctrl+S is pressed. I made multiple attempts to fix this for `shortcuts.js` but was unsuccessful. This error remains and may affect functionality if the Ctrl+S shortcut is used.
- I was also unable to apply refinements to the `showPanel` function in `ui.js` for managing `.active-panel` state more explicitly. The existing panel switching logic is functional but less robust than intended.